### PR TITLE
Add `default_kms_key` function

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,7 @@ import os
 
 
 def default_kms_key():
-    return None
+    return 'alias/ytsubs-token-encrypt-key'
 
 
 def getenv(key, default=None, /, *, integer=False, string=True):


### PR DESCRIPTION
Fill in the return string of this function with the KMS key identifier that should be used.

For #7