### PR TITLE
chore: copy the lint ignore list from `dev`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
         continue-on-error: false
         run: |
           target_version='py310'
-          ignore_csv_list='C408,C410,E701,E722,E731,UP018'
+          ignore_csv_list='C408,C410,E722,UP018'
           {
               echo '## Output from `ruff check`'
               echo ''

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
         continue-on-error: false
         run: |
           target_version='py310'
-          ignore_csv_list='E701,E722,E731'
+          ignore_csv_list='C408,C410,E701,E722,E731,UP018'
           {
               echo '## Output from `ruff check`'
               echo ''

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
         continue-on-error: false
         run: |
           target_version='py310'
-          ignore_csv_list='C408,C410,E722,UP018'
+          ignore_csv_list='C408,C410,UP018'
           {
               echo '## Output from `ruff check`'
               echo ''

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
         continue-on-error: false
         run: |
           target_version='py310'
-          ignore_csv_list='C408,C410,UP018'
+          ignore_csv_list='C408,C409,C410,UP018'
           {
               echo '## Output from `ruff check`'
               echo ''


### PR DESCRIPTION
The [default rules](https://docs.astral.sh/ruff/default-rules/) were recently expanded in [`ruff`](https://astral.sh/blog/ruff-v0.16.0).

This list is only adding rules for which there is fundamental disagreement.