### PR TITLE
chore: configure funding for GitHub and Ko-fi

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: [tcely]
+github: [tcely, derekantrican]
 ko_fi: derekantrican

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [tcely]
+ko_fi: derekantrican


### PR DESCRIPTION
> `.github/FUNDING.yml` shows the community how to support this project. Please see our [repository funding links documentation](https://docs.github.com/articles/displaying-a-sponsor-button-in-your-repository) for more information on formatting and what is and isn't allowed in this file.
> 
> Please note that funding links are currently disabled on this repository. Visit [repository settings](https://github.com/derekantrican/ytsubs/settings) to enable display of your funding links.

If you have your GitHub account ready to receive sponsors, you can add your username to the list. I didn't see any indication that it already was though.